### PR TITLE
Add check-regressions and rewrite-hashes skills

### DIFF
--- a/.claude/skills/check-regressions/SKILL.md
+++ b/.claude/skills/check-regressions/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: check-regressions
+description: Use when checking newton benchmark dashboard data (asv results) for performance regressions, when asked whether anything regressed in the last days, or when investigating a step change or anomaly in a benchmark series in this repo.
+---
+
+# Check Regressions
+
+## Overview
+
+Daily regression triage over the asv result JSONs in `results/<machine>/`. Core principle: the sweep only produces *candidates* — a finding is real only after the full series confirms it and the culprit bracket has been intersected **across machines**.
+
+Requires a newton checkout (default `~/git/newton`) to map snapshots to commits.
+
+## Workflow
+
+Run scripts from the repo root.
+
+1. **Sweep + health**: `python3 .claude/skills/check-regressions/scripts/check_regressions.py` (see `--help`). Reports machine freshness, series-continuity issues (disappeared benchmarks, version-hash mismatches), and median-vs-baseline flags.
+2. **Triage each flag**: `python3 .claude/skills/check-regressions/scripts/series.py <benchmark-substring> [param-filter]` — full per-machine series with snapshot hashes. Dismiss BIMODAL-tagged flags unless the step is sustained ≥2 snapshots AND consistent across machines. A regression that recovered inside the window is still a finding — report it as resolved-by.
+3. **Bracket the culprit**: snapshots are sparse — the culprit is in `(last-good, first-bad]`. Machines benchmark *different* snapshots: intersect the brackets from every machine/env before enumerating (Jetsons often ran an intermediate snapshot that pins a single commit). Then `git -C ~/git/newton log --oneline --first-parent LASTGOOD..FIRSTBAD`.
+4. **Classify every confirmed step — improvements too**:
+   - **workload change**: `git -C ~/git/newton log A..B -- asv/` is non-empty, or the example the benchmark wraps changed (check the benchmark's imports in newton's `asv/benchmarks/`). A step from these is a redefinition, not a perf change; it may need a hash-rewrite decision.
+   - **dependency bump**: diff the `requirements` dict between the last-good and first-bad result JSONs.
+   - **product change**: otherwise — name suspect commits from the bracket.
+   - To pick between suspects (including for recoveries), read their full messages and PR bodies: `git -C ~/git/newton log -1 --format=%B <sha>`, then `gh pr view <N> --repo newton-physics/newton` — fix PRs often name the exact example or benchmark.
+5. **Report** with the template below.
+
+## Report template
+
+The three flag sections are REQUIRED even when empty ("none"):
+
+- **Data freshness**: active machines silent >3 days.
+- **Series continuity**: disappeared/renamed benchmarks or hash mismatches. For each: "hash-rewrite decision needed" → use the `rewrite-hashes` skill. If the decision was already made (documented as an exclusion comment in `replace_hash.sh`), say so instead. DISAPPEARED flags age out once the baseline window passes the change.
+- **Findings**: per finding — benchmark, machines + magnitude, bracket (snapshot hashes), classification, suspect commit/PR, status (persisting | resolved-by X).
+- **Dismissed flags**: one line each — what the sweep flagged and why you dismissed it.
+
+## Known noise & machine facts (as of 2026-07)
+
+| Pattern | Behavior |
+|---|---|
+| `setup.bench_model.{Fast,Kpi}Initialize*` | bimodal, oscillates run-to-run |
+| `FastViewerGL.time_rendering_frame` | bimodal |
+| `CpuIKFranka` py3.12 only | modes ~0.26/0.31; py3.13 stable |
+| `HeightfieldCollision.time_simulate` | bimodal ~0.067/0.10, both modes within one run |
+| `SlowExample*.time_load` | single-shot compile time, ±15% jitter |
+
+SC-PV machines: py3.13 = Windows, py3.12 = Linux; the dashboard groups by `params.machine`. Retired dirs (>60 days silent, auto-excluded): `adenzler-asv-runner`, `ershi-asv*`. `SC-PV-SPARK-PS-07` (GB10) has a single run from 2026-06-24 — report its freshness flag but note it never came online properly.
+
+## Common mistakes
+
+- Bracketing from a single machine's snapshot sequence → a 30-commit suspect list where cross-machine intersection pins 1.
+- Reporting a large improvement without classifying it — a 10× step is usually a harness/workload change (e.g. graph capture added to examples), not free perf.
+- Treating a benchmark rename or new scene as a regression/improvement.
+- Trusting a single post-step data point — wait for a second snapshot before closing.
+- Dismissing a sustained step on one machine class as noise because other machines moved differently — hardware responds differently to the same change; a step that holds for ≥2 snapshots gets bracketed and classified, whatever the other machines did.
+- Param filters in series.py match repr strings — `'g1'` includes the quotes.

--- a/.claude/skills/check-regressions/SKILL.md
+++ b/.claude/skills/check-regressions/SKILL.md
@@ -9,7 +9,7 @@ description: Use when checking newton benchmark dashboard data (asv results) for
 
 Daily regression triage over the asv result JSONs in `results/<machine>/`. Core principle: the sweep only produces *candidates* — a finding is real only after the full series confirms it and the culprit bracket has been intersected **across machines**.
 
-Requires a newton checkout (default `~/git/newton`) to map snapshots to commits.
+Requires a local newton checkout to map snapshots to commits — `<newton>` below; locate or clone one (github.com/newton-physics/newton) before starting.
 
 ## Workflow
 
@@ -17,12 +17,12 @@ Run scripts from the repo root.
 
 1. **Sweep + health**: `python3 .claude/skills/check-regressions/scripts/check_regressions.py` (see `--help`). Reports machine freshness, series-continuity issues (disappeared benchmarks, version-hash mismatches), and median-vs-baseline flags.
 2. **Triage each flag**: `python3 .claude/skills/check-regressions/scripts/series.py <benchmark-substring> [param-filter]` — full per-machine series with snapshot hashes. Judge noise from the data, not from a fixed list: an OSCILLATING tag means the series alternates between levels instead of stepping once — dismiss when the full series confirms recent values sit inside the historical envelope (oscillation can be env-specific: the same benchmark may be bimodal on py3.12 and flat on py3.13, and single-shot compile-time benchmarks jitter ±15%). A real step transitions once — or twice if it recovered, which is still a finding: report it as resolved-by.
-3. **Bracket the culprit**: snapshots are sparse — the culprit is in `(last-good, first-bad]`. Machines benchmark *different* snapshots: intersect the brackets from every machine/env before enumerating (Jetsons often ran an intermediate snapshot that pins a single commit). Then `git -C ~/git/newton log --oneline --first-parent LASTGOOD..FIRSTBAD`.
+3. **Bracket the culprit**: snapshots are sparse — the culprit is in `(last-good, first-bad]`. Machines benchmark *different* snapshots: intersect the brackets from every machine/env before enumerating (Jetsons often ran an intermediate snapshot that pins a single commit). Then `git -C <newton> log --oneline --first-parent LASTGOOD..FIRSTBAD`.
 4. **Classify every confirmed step — improvements too**:
-   - **workload change**: `git -C ~/git/newton log A..B -- asv/` is non-empty, or the example the benchmark wraps changed (check the benchmark's imports in newton's `asv/benchmarks/`). A step from these is a redefinition, not a perf change; it may need a hash-rewrite decision.
+   - **workload change**: `git -C <newton> log A..B -- asv/` is non-empty, or the example the benchmark wraps changed (check the benchmark's imports in newton's `asv/benchmarks/`). A step from these is a redefinition, not a perf change; it may need a hash-rewrite decision.
    - **dependency bump**: diff the `requirements` dict between the last-good and first-bad result JSONs.
    - **product change**: otherwise — name suspect commits from the bracket.
-   - To pick between suspects (including for recoveries), read their full messages and PR bodies: `git -C ~/git/newton log -1 --format=%B <sha>`, then `gh pr view <N> --repo newton-physics/newton` — fix PRs often name the exact example or benchmark.
+   - To pick between suspects (including for recoveries), read their full messages and PR bodies: `git -C <newton> log -1 --format=%B <sha>`, then `gh pr view <N> --repo newton-physics/newton` — fix PRs often name the exact example or benchmark.
 5. **Report** with the template below.
 
 ## Report template

--- a/.claude/skills/check-regressions/SKILL.md
+++ b/.claude/skills/check-regressions/SKILL.md
@@ -34,10 +34,6 @@ The three flag sections are REQUIRED even when empty ("none"):
 - **Findings**: per finding — benchmark, machines + magnitude, bracket (snapshot hashes), classification, suspect commit/PR, status (persisting | resolved-by X).
 - **Dismissed flags**: one line each — what the sweep flagged and why you dismissed it.
 
-## Machine facts
-
-SC-PV machines: py3.13 = Windows, py3.12 = Linux; the dashboard groups by `params.machine`. Directories >60 days silent are treated as retired and auto-excluded by the sweep.
-
 ## Common mistakes
 
 - Bracketing from a single machine's snapshot sequence → a 30-commit suspect list where cross-machine intersection pins 1.

--- a/.claude/skills/check-regressions/SKILL.md
+++ b/.claude/skills/check-regressions/SKILL.md
@@ -16,7 +16,7 @@ Requires a newton checkout (default `~/git/newton`) to map snapshots to commits.
 Run scripts from the repo root.
 
 1. **Sweep + health**: `python3 .claude/skills/check-regressions/scripts/check_regressions.py` (see `--help`). Reports machine freshness, series-continuity issues (disappeared benchmarks, version-hash mismatches), and median-vs-baseline flags.
-2. **Triage each flag**: `python3 .claude/skills/check-regressions/scripts/series.py <benchmark-substring> [param-filter]` — full per-machine series with snapshot hashes. Dismiss BIMODAL-tagged flags unless the step is sustained ≥2 snapshots AND consistent across machines. A regression that recovered inside the window is still a finding — report it as resolved-by.
+2. **Triage each flag**: `python3 .claude/skills/check-regressions/scripts/series.py <benchmark-substring> [param-filter]` — full per-machine series with snapshot hashes. Judge noise from the data, not from a fixed list: an OSCILLATING tag means the series alternates between levels instead of stepping once — dismiss when the full series confirms recent values sit inside the historical envelope (oscillation can be env-specific: the same benchmark may be bimodal on py3.12 and flat on py3.13, and single-shot compile-time benchmarks jitter ±15%). A real step transitions once — or twice if it recovered, which is still a finding: report it as resolved-by.
 3. **Bracket the culprit**: snapshots are sparse — the culprit is in `(last-good, first-bad]`. Machines benchmark *different* snapshots: intersect the brackets from every machine/env before enumerating (Jetsons often ran an intermediate snapshot that pins a single commit). Then `git -C ~/git/newton log --oneline --first-parent LASTGOOD..FIRSTBAD`.
 4. **Classify every confirmed step — improvements too**:
    - **workload change**: `git -C ~/git/newton log A..B -- asv/` is non-empty, or the example the benchmark wraps changed (check the benchmark's imports in newton's `asv/benchmarks/`). A step from these is a redefinition, not a perf change; it may need a hash-rewrite decision.
@@ -34,21 +34,14 @@ The three flag sections are REQUIRED even when empty ("none"):
 - **Findings**: per finding — benchmark, machines + magnitude, bracket (snapshot hashes), classification, suspect commit/PR, status (persisting | resolved-by X).
 - **Dismissed flags**: one line each — what the sweep flagged and why you dismissed it.
 
-## Known noise & machine facts (as of 2026-07)
+## Machine facts
 
-| Pattern | Behavior |
-|---|---|
-| `setup.bench_model.{Fast,Kpi}Initialize*` | bimodal, oscillates run-to-run |
-| `FastViewerGL.time_rendering_frame` | bimodal |
-| `CpuIKFranka` py3.12 only | modes ~0.26/0.31; py3.13 stable |
-| `HeightfieldCollision.time_simulate` | bimodal ~0.067/0.10, both modes within one run |
-| `SlowExample*.time_load` | single-shot compile time, ±15% jitter |
-
-SC-PV machines: py3.13 = Windows, py3.12 = Linux; the dashboard groups by `params.machine`. Retired dirs (>60 days silent, auto-excluded): `adenzler-asv-runner`, `ershi-asv*`. `SC-PV-SPARK-PS-07` (GB10) has a single run from 2026-06-24 — report its freshness flag but note it never came online properly.
+SC-PV machines: py3.13 = Windows, py3.12 = Linux; the dashboard groups by `params.machine`. Directories >60 days silent are treated as retired and auto-excluded by the sweep.
 
 ## Common mistakes
 
 - Bracketing from a single machine's snapshot sequence → a 30-commit suspect list where cross-machine intersection pins 1.
+- Dismissing or confirming a flag from its tags alone — OSCILLATING/NOISY are hints computed on a short window; the full series decides.
 - Reporting a large improvement without classifying it — a 10× step is usually a harness/workload change (e.g. graph capture added to examples), not free perf.
 - Treating a benchmark rename or new scene as a regression/improvement.
 - Trusting a single post-step data point — wait for a second snapshot before closing.

--- a/.claude/skills/check-regressions/scripts/check_regressions.py
+++ b/.claude/skills/check-regressions/scripts/check_regressions.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Daily regression sweep over asv result files.
+
+Sections:
+  1. Machine freshness   -- active machines that stopped reporting
+  2. Series continuity   -- disappeared/appeared benchmarks, version-hash mismatches
+  3. Regression sweep    -- recent-window medians vs prior baseline per (machine, env)
+
+Run from the newton-asv repo root. Flags are CANDIDATES: confirm each one against the
+full series (series.py) and the workflow in SKILL.md before reporting.
+"""
+
+import argparse
+import datetime
+import glob
+import json
+import os
+import statistics
+
+# Known oscillators: (benchmark substring, env substring or None). See SKILL.md.
+BIMODAL = [
+    ("setup.bench_model.FastInitialize", None),
+    ("setup.bench_model.KpiInitialize", None),
+    ("simulation.bench_viewer.FastViewerGL", None),
+    ("simulation.bench_cpu.CpuIKFranka", "py3.12"),
+    ("simulation.bench_heightfield.HeightfieldCollision", None),
+]
+SILENT_FLAG_DAYS = 3    # active machine with no data for longer -> flag
+RETIRED_AFTER_DAYS = 60  # no data for longer -> considered retired, not flagged
+
+
+def is_bimodal(name, env):
+    return any(s in name and (e is None or e in env) for s, e in BIMODAL)
+
+
+def load_runs(root):
+    """[(machine_dir, env, date_ms, parsed_json)] for all result files."""
+    runs = []
+    for mdir in sorted(os.listdir(root)):
+        full = os.path.join(root, mdir)
+        if not os.path.isdir(full) or mdir.startswith("."):
+            continue
+        for f in glob.glob(os.path.join(full, "*.json")):
+            if f.endswith("machine.json"):
+                continue
+            try:
+                d = json.load(open(f))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if "results" in d:
+                runs.append((mdir, d.get("env_name", "?"), d.get("date", 0), d))
+    return runs
+
+
+def extract(d):
+    """{(benchmark, param_string): value} for one result file."""
+    cols = d.get("result_columns", [])
+    out = {}
+    for name, row in d["results"].items():
+        if not isinstance(row, list) or not row:
+            continue
+        rec = dict(zip(cols, row))
+        vals = rec.get("result")
+        if vals is None:
+            continue
+        combos = [[]]
+        for plist in rec.get("params") or []:
+            combos = [c + [p] for c in combos for p in plist]
+        if len(combos) != len(vals):
+            combos = [[str(i)] for i in range(len(vals))]
+        for c, v in zip(combos, vals):
+            if isinstance(v, (int, float)):
+                out[(name, ", ".join(c))] = v
+    return out
+
+
+def versions(d):
+    """{benchmark: version_hash} for one result file."""
+    cols = d.get("result_columns", [])
+    if "version" not in cols:
+        return {}
+    vidx = cols.index("version")
+    return {n: row[vidx] for n, row in d["results"].items()
+            if isinstance(row, list) and len(row) > vidx}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default="results")
+    ap.add_argument("--days", type=int, default=3,
+                    help="recent window, relative to each machine's newest run (default 3)")
+    ap.add_argument("--threshold", type=float, default=1.05,
+                    help="flag ratio (default 1.05 = +/-5%%)")
+    ap.add_argument("--baseline-n", type=int, default=8,
+                    help="baseline runs before the window (default 8)")
+    args = ap.parse_args()
+
+    runs = load_runs(args.root)
+    now = datetime.datetime.now()
+
+    # --- 1. machine freshness ---
+    print("=== 1. Machine freshness ===")
+    latest_by_machine = {}
+    for mdir, _, dt, _ in runs:
+        latest_by_machine[mdir] = max(latest_by_machine.get(mdir, 0), dt)
+    retired = []
+    for mdir, dt in sorted(latest_by_machine.items()):
+        age = (now - datetime.datetime.fromtimestamp(dt / 1000)).days
+        stamp = datetime.datetime.fromtimestamp(dt / 1000).strftime("%Y-%m-%d")
+        if age > RETIRED_AFTER_DAYS:
+            retired.append(f"{mdir} (last {stamp})")
+        elif age > SILENT_FLAG_DAYS:
+            print(f"  FLAG: {mdir} silent for {age} days (last {stamp})")
+        else:
+            print(f"  ok:   {mdir} (last {stamp})")
+    if retired:
+        print(f"  retired (not flagged): {'; '.join(retired)}")
+
+    # group runs per (machine, env), newest last
+    bymachine = {}
+    for mdir, env, dt, d in runs:
+        bymachine.setdefault((mdir, env), []).append((dt, d))
+    for lst in bymachine.values():
+        lst.sort(key=lambda x: x[0])
+
+    def split_window(lst):
+        """(baseline_runs, recent_runs) using the machine's own newest run as anchor."""
+        anchor = lst[-1][0]
+        cutoff = anchor - args.days * 86400_000
+        recent = [x for x in lst if x[0] > cutoff]
+        base = [x for x in lst if x[0] <= cutoff][-args.baseline_n:]
+        return base, recent
+
+    active = {k: lst for k, lst in bymachine.items()
+              if (now - datetime.datetime.fromtimestamp(lst[-1][0] / 1000)).days
+              <= RETIRED_AFTER_DAYS}
+
+    # --- 2. series continuity ---
+    print("\n=== 2. Series continuity (disappeared/appeared benchmarks, hash mismatches) ===")
+    bj_path = os.path.join(args.root, "benchmarks.json")
+    current = {}
+    if os.path.exists(bj_path):
+        bj = json.load(open(bj_path))
+        current = {k: v.get("version") for k, v in bj.items()
+                   if isinstance(v, dict) and "version" in v}
+    disappeared, appeared, mismatched = {}, {}, {}
+    for (mdir, env), lst in sorted(active.items()):
+        base, recent = split_window(lst)
+        if not base or not recent:
+            continue
+        base_keys = set().union(*(set(d["results"]) for _, d in base))
+        new_keys = set(recent[-1][1]["results"])
+        for k in sorted(base_keys - new_keys):
+            disappeared.setdefault(k, []).append(f"{mdir}/{env}")
+        for k in sorted(new_keys - base_keys):
+            appeared.setdefault(k, []).append(f"{mdir}/{env}")
+        if current:
+            for k, v in versions(recent[-1][1]).items():
+                if k in current and v != current[k]:
+                    mismatched.setdefault(k, []).append(f"{mdir}/{env}")
+    for label, d in [("DISAPPEARED", disappeared), ("appeared", appeared),
+                     ("HASH MISMATCH vs benchmarks.json", mismatched)]:
+        for k, machines in sorted(d.items()):
+            print(f"  {label}: {k} ({len(machines)} machine/envs)")
+    if disappeared or mismatched:
+        print("  -> rename or benchmark-source change: hash-rewrite DECISION needed"
+              " (see rewrite-hashes skill)")
+    if not (disappeared or appeared or mismatched):
+        print("  none")
+
+    # --- 3. regression sweep ---
+    print("\n=== 3. Regression sweep (recent median vs baseline median) ===")
+    report = []
+    for (mdir, env), lst in sorted(active.items()):
+        base, recent = split_window(lst)
+        if len(base) < 3 or not recent:
+            continue
+        base_ex = [extract(d) for _, d in base]
+        rec_ex = [extract(d) for _, d in recent]
+        keys = set().union(*base_ex, *rec_ex)
+        for k in sorted(keys):
+            bvals = [e[k] for e in base_ex if k in e]
+            rvals = [e[k] for e in rec_ex if k in e]
+            if len(bvals) < 3 or not rvals:
+                continue
+            bmed, rmed = statistics.median(bvals), statistics.median(rvals)
+            if bmed <= 0:
+                continue
+            ratio = rmed / bmed
+            if ratio >= args.threshold or ratio <= 1 / args.threshold:
+                spread = max(bvals) / min(bvals) if min(bvals) > 0 else float("inf")
+                report.append((ratio, mdir, env, k, bmed, rmed,
+                               len(bvals), len(rvals), spread))
+    report.sort(key=lambda r: -r[0])
+    for ratio, mdir, env, (name, params), bmed, rmed, nb, nr, spread in report:
+        tags = ""
+        if is_bimodal(name, env):
+            tags += " BIMODAL"
+        if spread > 1.3:
+            tags += " NOISY"
+        p = f" [{params}]" if params else ""
+        print(f"  {ratio:5.2f} {mdir[:26]:<26} {env:<20} {name}{p}"
+              f"  {bmed:.4g}->{rmed:.4g} (n={nb}/{nr}, spread x{spread:.2f}){tags}")
+    if not report:
+        print("  none")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/check-regressions/scripts/check_regressions.py
+++ b/.claude/skills/check-regressions/scripts/check_regressions.py
@@ -17,20 +17,23 @@ import json
 import os
 import statistics
 
-# Known oscillators: (benchmark substring, env substring or None). See SKILL.md.
-BIMODAL = [
-    ("setup.bench_model.FastInitialize", None),
-    ("setup.bench_model.KpiInitialize", None),
-    ("simulation.bench_viewer.FastViewerGL", None),
-    ("simulation.bench_cpu.CpuIKFranka", "py3.12"),
-    ("simulation.bench_heightfield.HeightfieldCollision", None),
-]
 SILENT_FLAG_DAYS = 3    # active machine with no data for longer -> flag
 RETIRED_AFTER_DAYS = 60  # no data for longer -> considered retired, not flagged
 
 
-def is_bimodal(name, env):
-    return any(s in name and (e is None or e in env) for s, e in BIMODAL)
+def is_oscillating(history):
+    """True if a chronological series alternates between levels rather than
+    stepping once. A real step crosses the midline once (twice if it recovered);
+    bimodal noise crosses it repeatedly."""
+    if len(history) < 6:
+        return False
+    lo, hi = min(history), max(history)
+    if lo <= 0 or hi / lo < 1.05:
+        return False
+    mid = (lo + hi) / 2
+    sides = [v > mid for v in history]
+    transitions = sum(a != b for a, b in zip(sides, sides[1:]))
+    return transitions >= 3
 
 
 def load_runs(root):
@@ -191,12 +194,13 @@ def main():
             if ratio >= args.threshold or ratio <= 1 / args.threshold:
                 spread = max(bvals) / min(bvals) if min(bvals) > 0 else float("inf")
                 report.append((ratio, mdir, env, k, bmed, rmed,
-                               len(bvals), len(rvals), spread))
+                               len(bvals), len(rvals), spread,
+                               is_oscillating(bvals + rvals)))
     report.sort(key=lambda r: -r[0])
-    for ratio, mdir, env, (name, params), bmed, rmed, nb, nr, spread in report:
+    for ratio, mdir, env, (name, params), bmed, rmed, nb, nr, spread, osc in report:
         tags = ""
-        if is_bimodal(name, env):
-            tags += " BIMODAL"
+        if osc:
+            tags += " OSCILLATING"
         if spread > 1.3:
             tags += " NOISY"
         p = f" [{params}]" if params else ""

--- a/.claude/skills/check-regressions/scripts/series.py
+++ b/.claude/skills/check-regressions/scripts/series.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Dump the full time series of a benchmark per machine, with snapshot hashes.
+
+Usage: series.py BENCHMARK_SUBSTRING [PARAM_FILTER]
+
+PARAM_FILTER matches the repr'd param string, so quote accordingly: "'g1'" or "8192".
+Use the printed snapshot hashes for (last-good, first-bad] bracketing across machines.
+Run from the newton-asv repo root.
+"""
+
+import argparse
+import datetime
+import glob
+import json
+import os
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("benchmark", help="substring of the benchmark name")
+    ap.add_argument("param_filter", nargs="?", help="substring of the param repr string")
+    ap.add_argument("--root", default="results")
+    ap.add_argument("--last", type=int, default=16, help="rows per machine (default 16)")
+    ap.add_argument("--all", action="store_true", help="show the entire series")
+    args = ap.parse_args()
+
+    for mdir in sorted(os.listdir(args.root)):
+        full = os.path.join(args.root, mdir)
+        if not os.path.isdir(full) or mdir.startswith("."):
+            continue
+        rows = []
+        for f in glob.glob(os.path.join(full, "*.json")):
+            if f.endswith("machine.json"):
+                continue
+            try:
+                d = json.load(open(f))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if "results" not in d:
+                continue
+            cols = d.get("result_columns", [])
+            for name, row in d["results"].items():
+                if args.benchmark not in name or not isinstance(row, list):
+                    continue
+                rec = dict(zip(cols, row))
+                vals = rec.get("result")
+                if vals is None:
+                    continue
+                combos = [[]]
+                for plist in rec.get("params") or []:
+                    combos = [c + [p] for c in combos for p in plist]
+                if len(combos) != len(vals):
+                    combos = [[str(i)] for i in range(len(vals))]
+                for c, v in zip(combos, vals):
+                    pstr = ", ".join(c)
+                    if args.param_filter and args.param_filter not in pstr:
+                        continue
+                    if isinstance(v, (int, float)):
+                        rows.append((d.get("date", 0), d.get("commit_hash", "?")[:9],
+                                     d.get("env_name", "?"), pstr, v))
+        if not rows:
+            continue
+        rows.sort()
+        print(f"\n=== {mdir} ===")
+        for dt, ch, env, pstr, v in rows if args.all else rows[-args.last:]:
+            ds = datetime.datetime.fromtimestamp(dt / 1000).strftime("%m-%d")
+            p = f" [{pstr}]" if pstr else ""
+            print(f"  {ds} {ch} {env:<20}{p} {v:.5g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/rewrite-hashes/SKILL.md
+++ b/.claude/skills/rewrite-hashes/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: rewrite-hashes
+description: Use when a dashboard benchmark series ends or splits while the benchmark still runs — after newton renames a benchmark or changes its source (asv version hash), or when check-regressions flags hash mismatches or disappeared benchmarks.
+---
+
+# Rewrite Benchmark Hashes
+
+## Overview
+
+asv matches results to a dashboard series by benchmark key + `version` hash (hash of the benchmark source). When newton changes a benchmark, old result files keep the old hash and the dashboard starts a new series. `results/adenzler-asv-runner/replace_hash.sh` holds a name→current-hash map (must match `results/benchmarks.json`) and rewrites the hashes inside all result JSONs to reconnect history.
+
+Prerequisite: at least one post-change automation run has landed, so `results/benchmarks.json` already contains the new hashes.
+
+## Decision gate — before touching anything
+
+Merging history claims "same workload, numbers comparable". Verify per benchmark:
+
+1. What changed? `git -C ~/git/newton log -p <range> -- asv/` for the benchmark file AND the example it wraps (check imports in newton's `asv/benchmarks/`).
+2. Is there a step at the series boundary? (`series.py` from the check-regressions skill)
+
+- Timing-irrelevant change (rename, comments, untimed setup) and no boundary step → **merge** (procedures below).
+- Workload / timed region / scene changed, or a boundary step exists → **do NOT merge**: remove or don't add the entry in replace_hash.sh, with a comment documenting the exclusion. Precedent: tiled-camera #3480 (new scene — old series deliberately ends 2026-07-14).
+- Unsure → ask the user. A wrong merge bakes a fake step into the dashboard permanently; the old series stays recoverable either way, but nobody notices a quiet bad merge.
+
+Never add a benchmark to replace_hash.sh just because an audit finds it "missing" — absence may be a deliberate exclusion, and the reflex once silently rewrote 109 result files across a timed-region change.
+
+## Procedures
+
+| Case | What to do | Precedent commit |
+|---|---|---|
+| Same name, new hash | Update the entry in replace_hash.sh from benchmarks.json; run `./replace_hash.sh <path-to-results>` | most history of the script |
+| Renamed, hash unchanged | Rename the key in all historical result JSONs; update script entries | `1cd00414` |
+| Renamed, old+new keys coexist in files | Merge rows: union the param combos so retired values stay under their old params | `292e16b9` |
+
+`git show <precedent>` shows the exact mechanics for the rename/merge cases.
+
+## Verify and land
+
+- `git diff --stat`: only intended files. Spot-check a hunk: only 64-hex version strings (or renamed keys) changed.
+- Re-dump one affected series: continuous, no artificial boundary step.
+- Convention: these maintenance commits land directly on main (data repo). Remote pushes still need explicit user approval.
+
+## Common mistakes
+
+- Running before benchmarks.json has the new hashes — rewrites history to stale values.
+- Forgetting the script defaults to its *own* directory — pass the results root explicitly.
+- Treating replace_hash.sh as an exhaustive registry. It is a merge tool; a benchmark not listed is a decision, not an oversight.

--- a/.claude/skills/rewrite-hashes/SKILL.md
+++ b/.claude/skills/rewrite-hashes/SKILL.md
@@ -15,7 +15,7 @@ Prerequisite: at least one post-change automation run has landed, so `results/be
 
 Merging history claims "same workload, numbers comparable". Verify per benchmark:
 
-1. What changed? `git -C ~/git/newton log -p <range> -- asv/` for the benchmark file AND the example it wraps (check imports in newton's `asv/benchmarks/`).
+1. What changed? `git -C <newton> log -p <range> -- asv/` for the benchmark file AND the example it wraps (check imports in newton's `asv/benchmarks/`), where `<newton>` is a local checkout of github.com/newton-physics/newton.
 2. Is there a step at the series boundary? (`series.py` from the check-regressions skill)
 
 - Timing-irrelevant change (rename, comments, untimed setup) and no boundary step → **merge** (procedures below).

--- a/.claude/skills/rewrite-hashes/SKILL.md
+++ b/.claude/skills/rewrite-hashes/SKILL.md
@@ -13,14 +13,20 @@ Prerequisite: at least one post-change automation run has landed, so `results/be
 
 ## Decision gate — before touching anything
 
-Merging history claims "same workload, numbers comparable". Verify per benchmark:
+Establish the facts per benchmark:
 
 1. What changed? `git -C <newton> log -p <range> -- asv/` for the benchmark file AND the example it wraps (check imports in newton's `asv/benchmarks/`), where `<newton>` is a local checkout of github.com/newton-physics/newton.
-2. Is there a step at the series boundary? (`series.py` from the check-regressions skill)
+2. Is there a step at the series boundary? (`series.py` from the check-regressions skill — note the magnitude per machine.)
 
-- Timing-irrelevant change (rename, comments, untimed setup) and no boundary step → **merge** (procedures below).
-- Workload / timed region / scene changed, or a boundary step exists → **do NOT merge**: remove or don't add the entry in replace_hash.sh, with a comment documenting the exclusion. Precedent: tiled-camera #3480 (new scene — old series deliberately ends 2026-07-14).
-- Unsure → ask the user. A wrong merge bakes a fake step into the dashboard permanently; the old series stays recoverable either way, but nobody notices a quiet bad merge.
+Timing-irrelevant change (pure rename, comments, untimed setup) with no boundary step → **merge** (procedures below).
+
+Anything else — workload, timed region, or scene changed, or a boundary step exists — is a product decision with no clean rule: continuous history is often worth more than strict comparability, so "the setup changed" does **not** imply "don't merge". Never decide this yourself. Present the evidence (what changed, step magnitude per machine) and ask the user, offering:
+
+- **Merge**: history stays continuous; the change appears as a known, documented step in the series. Often right when it's still "the same benchmark", measured somewhat differently.
+- **Don't merge**: old series ends, new baseline starts; drop/skip the replace_hash.sh entry with a comment documenting the exclusion (precedent: tiled-camera #3480, new scene).
+- **Defer**: leave as-is until more post-change data exists to judge the step.
+
+Raw old data stays in the result files either way; whichever way it goes, record the decision in the commit message and a script comment so it isn't re-litigated.
 
 Never add a benchmark to replace_hash.sh just because an audit finds it "missing" — absence may be a deliberate exclusion, and the reflex once silently rewrote 109 result files across a timed-region change.
 


### PR DESCRIPTION
Adds two in-repo Claude Code skills under `.claude/skills/` so the daily dashboard triage and the series-continuity maintenance can be run by anyone without tribal knowledge.

**check-regressions** is the analysis entry point. Its sweep script reports machine freshness (active machines gone silent), series-continuity issues (disappeared/appeared benchmarks and version-hash mismatches against `results/benchmarks.json`), and median-vs-baseline flags with known-bimodal benchmarks tagged. The skill then prescribes the triage steps that make findings trustworthy: confirm each flag against the full series, intersect `(last-good, first-bad]` brackets across machines to pin culprits (different machines benchmark different snapshots), and classify every step as product change, benchmark/workload change, or dependency bump before reporting.

**rewrite-hashes** is the maintenance entry point for when a benchmark's asv version hash changes or it is renamed. It documents the `replace_hash.sh` mechanics and the three procedures (hash refresh, key rename, collision merge via param-combo union) with precedent commits, and leads with the decision gate: only merge history when the workload is verifiably comparable, otherwise document the exclusion.

Both skills were validated by running the same scenarios with and without the skill loaded and closing the gaps observed in the unaided runs.
